### PR TITLE
Hotfix: Model간 관계 수정

### DIFF
--- a/music_streaming/models.py
+++ b/music_streaming/models.py
@@ -1,15 +1,15 @@
 import json
 from neomodel import (
                 StructuredNode, StringProperty, RelationshipTo,
-                 One, RelationshipFrom, OneOrMore, UniqueIdProperty
+                 ZeroOrOne,ZeroOrMore, RelationshipFrom, UniqueIdProperty
                 )
 
 
 class Song(StructuredNode):
     uuid     = UniqueIdProperty()
     name     = StringProperty()
-    album    = RelationshipTo('Album', 'belongsto', cardinality=One)
-    musician = RelationshipTo('Musician', 'writtenby', cardinality=OneOrMore)
+    album    = RelationshipTo('Album', 'belongsto', cardinality=ZeroOrOne)
+    musician = RelationshipTo('Musician', 'writtenby', cardinality=ZeroOrMore)
 
     def to_dictionary(self): 
         data = json.loads(json.dumps(self.__properties__, ensure_ascii=False))
@@ -21,7 +21,7 @@ class Song(StructuredNode):
 class Album(StructuredNode):
     uuid = UniqueIdProperty()
     name = StringProperty()
-    song = RelationshipFrom('Song', 'belongsto', cardinality=OneOrMore)
+    song = RelationshipFrom('Song', 'belongsto', cardinality=ZeroOrMore)
 
     def to_dictionary(self): 
         data = json.loads(json.dumps(self.__properties__, ensure_ascii=False))
@@ -33,7 +33,7 @@ class Album(StructuredNode):
 class Musician(StructuredNode):
     uuid = UniqueIdProperty()
     name = StringProperty()
-    song = RelationshipFrom('Song', 'writtenby', cardinality=OneOrMore)
+    song = RelationshipFrom('Song', 'writtenby', cardinality=ZeroOrMore)
 
     def to_dictionary(self): 
         data = json.loads(json.dumps(self.__properties__, ensure_ascii=False))


### PR DESCRIPTION
- 아래와 같이 모델의 관계 변경
 - One > ZeroOrOne
 - OneOrMore > ZeroOrMore

- 기존에는 관계가 One이나 OneOrMore 이였기 때문에, 관계를
  맺을때는(connect) 문제가 없지만 관계를 끊을 때(disconnect), 마지막
관계이면 Zoro가 되기 때문에 서버에러가 발생하여 수정함.